### PR TITLE
Changed doc for `context.fd()` to use `poll`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -334,16 +334,13 @@ impl Libinput {
     /// Call into `dispatch` if any events become available on this fd.
     ///
     /// The most simple variant to check for available bytes is to use
-    /// the `libc`:
+    /// `nix::poll`:
     ///
-    ///     loop {
-    ///         let mut count = 0i32;
-    ///         libc::ioctl(context.fd(), libc::FIONREAD, &mut count);
-    ///         if (count > 0) {
-    ///             context.dispatch().unwrap();
-    ///             for event in context {
-    ///                 // do some processing...
-    ///             }
+    ///     let pollfd = poll::PollFd::new(context.as_raw_fd(), poll:POLLIN);
+    ///     while poll::poll(&mut [pollfd], -1).is_ok() {
+    ///         context.dispatch().unwrap();
+    ///         for event in context {
+    ///             // do some processing...
     ///         }
     ///     }
     ///


### PR DESCRIPTION
Hi,

Using `ioctl` gives me some `ioctl(3, FIONREAD, 0x7fff8b8a38c4) = -1 ENOTTY  (Inappropriate ioctl for device)`, but using `poll` as for example in https://github.com/wayland-project/libinput/blob/master/tools/libinput-debug-events.c#L898 works wonders.

`libc` also has it's `poll` implementation, but it requires to use some lower-level C structs, so I guess `nix::poll` is cleaner?

Cheers!