### PR TITLE
Update udev dependency to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "libinput bindings for rust"
 license = "MIT"
 documentation = "https://Drakulix.github.io/input.rs"
 repository = "https://github.com/Drakulix/input.rs"
-version = "0.4.1"
+version = "0.5.1"
 keywords = ["wayland", "input", "bindings"]
 categories = ["external-ffi-bindings"]
 authors = ["Drakulix (Victor Brekenfeld)"]
@@ -13,7 +13,7 @@ authors = ["Drakulix (Victor Brekenfeld)"]
 input-sys = { version = "1.9.0", path = "./input-sys" }
 libc = "0.2"
 bitflags = "1.0.0"
-udev = { version = "0.2", optional = true }
+udev = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 nix = "0.13"

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 Add to your Cargo.toml
 ```
-input = "0.4"
+input = "0.5"
 ```

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,7 +3,7 @@ use event::tablet_pad::TabletPadModeGroup;
 use event::switch::Switch;
 use std::ffi::{CStr, CString};
 #[cfg(feature = "udev")]
-use udev::{Context as UdevContext, Device as UdevDevice, FromRawWithContext};
+use udev::{Device as UdevDevice, FromRaw as UdevFromRaw};
 
 /// Capabilities on a device.
 ///
@@ -323,12 +323,12 @@ impl Device {
     /// The result of this function is not definied if the passed udev `Context`
     /// is not the same as the one the libinput `Context` was created from.
     #[cfg(feature = "udev")]
-    pub unsafe fn udev_device(&self, context: &UdevContext) -> Option<UdevDevice> {
+    pub unsafe fn udev_device(&self) -> Option<UdevDevice> {
         let ptr = ffi::libinput_device_get_udev_device(self.ffi) as *mut _;
         if ptr.is_null() {
             None
         } else {
-            Some(UdevDevice::from_raw(&context, ptr))
+            Some(UdevDevice::from_raw(ptr))
         }
     }
 


### PR DESCRIPTION
The changes are following:
* Remove Context from everywhere, pass nullptr to C API.
* Fix all warnings but one (device.rs, line 328: call returns ptr to input_sys::udev, but Device::from_raw expects libudev_sys::udev; `as *mut _` hides actual problem). 
* Increase version number by 1.0 for the changes are breaking.