### PR TITLE
On crates.io the documatiation link is broken.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "input"
 description = "libinput bindings for rust"
 license = "MIT"
-documentation = "https://Drakulix.github.io/input.rs"
+documentation = "https://docs.rs/input"
 repository = "https://github.com/Drakulix/input.rs"
 version = "0.5.0"
 keywords = ["wayland", "input", "bindings"]


### PR DESCRIPTION
Fixes link to documentation in Cargo.toml