### PR TITLE
Fix typo in documentation example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! }
 //! 
 //! fn main() {
-//! 	let mut input = Libinput::new_with_udev(Interfacep());
+//! 	let mut input = Libinput::new_with_udev(Interface{});
 //! 	input.udev_assign_seat("seat0").unwrap();
 //! 	loop {
 //! 		input.dispatch().unwrap();


### PR DESCRIPTION
## Description

Fix a small typo in the example at the `Getting started` section.

## Additional details

For context, I was exploring your (very nice!) library for a personal project and trying to execute the main example - hope the small fix is useful to get the example ready to run after copy-pasting it!