### PR TITLE
build.rs: Add /usr/local/include to bindgen path

### DIFF
--- a/input-sys/build.rs
+++ b/input-sys/build.rs
@@ -71,6 +71,10 @@ fn main() {
 
         // Setup bindings builder
         let generated = bindgen::builder()
+            .clang_arg(match cfg!(target_os = "freebsd") {
+                true => "-I/usr/local/include",
+                false => "",
+            })
             .header(header.display().to_string())
             .ctypes_prefix("::libc")
             .whitelist_type(r"^libinput_.*$")


### PR DESCRIPTION
Building with FreeBSD complains that there are no prebuilt bindings and tells us to use the gen feature. The gen feature fails because it can't find udev.h in `/usr/include`. This adds a clang arg to the bindgen call to include `/usr/local/include` to get the FreeBSD (and probably other platforms) build working again.