### PR TITLE
doc: add instructions for installing libinput-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Add to your `Cargo.toml`:
 input = "0.7"
 ```
 
+Install the libinput dev dependencies:
+
+Ubuntu:
+```
+apt-get install libinput-dev
+```
+Fedora
+```
+dnf install libinput-devel
+```
+
 Configure and run event loop:
 
 ```rust


### PR DESCRIPTION
Add required compiling dependencies to readme. If any of these are wrong or you think this needs more, please comment.