### PR TITLE
Fix bitflag tests

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,6 @@
+// TODO Error type instead of `Result<_, ()>`
+#![allow(clippy::result_unit_err)]
+
 use crate::{ffi, AsRaw, Device, Event, FromRaw};
 use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::{
@@ -177,7 +180,7 @@ impl Libinput {
             close_restricted: Some(close_restricted::<I>),
         });
 
-        let context = unsafe {
+        unsafe {
             let udev = udev::udev_new();
             let libinput = ffi::libinput_udev_create_context(
                 Box::into_raw(boxed_interface),
@@ -189,9 +192,7 @@ impl Libinput {
                 ffi: libinput,
                 _interface: Some(boxed_userdata as Rc<dyn LibinputInterface>),
             }
-        };
-
-        context
+        }
     }
 
     /// Create a new libinput context that requires the caller to manually add or remove devices.
@@ -213,7 +214,7 @@ impl Libinput {
             close_restricted: Some(close_restricted::<I>),
         });
 
-        let context = Libinput {
+        Libinput {
             ffi: unsafe {
                 ffi::libinput_path_create_context(
                     Box::into_raw(boxed_interface),
@@ -221,9 +222,7 @@ impl Libinput {
                 )
             },
             _interface: Some(boxed_userdata as Rc<dyn LibinputInterface>),
-        };
-
-        context
+        }
     }
 
     /// Add a device to a libinput context initialized with

--- a/src/device.rs
+++ b/src/device.rs
@@ -816,13 +816,13 @@ impl Device {
         let bitmask = unsafe { ffi::libinput_device_config_click_get_methods(self.as_raw_mut()) };
         if bitmask
             & ffi::libinput_config_click_method_LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER as u32
-            == bitmask
+            != 0
         {
             methods.push(ClickMethod::Clickfinger);
         }
         if bitmask
             & ffi::libinput_config_click_method_LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS as u32
-            == bitmask
+            != 0
         {
             methods.push(ClickMethod::ButtonAreas);
         }
@@ -1268,22 +1268,18 @@ impl Device {
     pub fn config_scroll_methods(&self) -> Vec<ScrollMethod> {
         let mut methods = Vec::new();
         let bitmask = unsafe { ffi::libinput_device_config_scroll_get_methods(self.as_raw_mut()) };
-        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_NO_SCROLL as u32
-            == bitmask
+        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_NO_SCROLL as u32 != 0
         {
             methods.push(ScrollMethod::NoScroll);
         }
-        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_2FG as u32 == bitmask
-        {
+        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_2FG as u32 != 0 {
             methods.push(ScrollMethod::TwoFinger);
         }
-        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_EDGE as u32
-            == bitmask
-        {
+        if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_EDGE as u32 != 0 {
             methods.push(ScrollMethod::Edge);
         }
         if bitmask & ffi::libinput_config_scroll_method_LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN as u32
-            == bitmask
+            != 0
         {
             methods.push(ScrollMethod::OnButtonDown);
         }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,3 +1,12 @@
+// Allow unnecessary casts since ffi types may differ by C ABI
+// TODO Error type instead of `Result<_, ()>`
+// TODO Better way to handle `SendEventsMode::ENABLED` being 0?
+#![allow(
+    clippy::bad_bit_mask,
+    clippy::result_unit_err,
+    clippy::unnecessary_cast
+)]
+
 use crate::{
     event::{switch::Switch, tablet_pad::TabletPadModeGroup},
     ffi, AsRaw, FromRaw, Libinput, Seat,


### PR DESCRIPTION
The correct idiom is `== <FLAG>`, not `== bitmask`. But that's rather verbose here. `!= 0` should be fine as long as each of these flags is a single bit.

This fixes an issue with cosmic-comp where entries in `~/.local/state/cosmic-comp/inputs.ron` have `scroll_config` values despite having nothing to do with scrolling.