### PR TITLE
Fix clippy errors in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Configure and run event loop:
 
 ```rust
 use input::{Libinput, LibinputInterface};
-use libc::{O_RDONLY, O_RDWR, O_WRONLY};
+use libc::{O_ACCMODE, O_RDONLY, O_RDWR, O_WRONLY};
 use std::fs::{File, OpenOptions};
 use std::os::unix::{fs::OpenOptionsExt, io::OwnedFd};
 use std::path::Path;
@@ -46,8 +46,8 @@ impl LibinputInterface for Interface {
     fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
         OpenOptions::new()
             .custom_flags(flags)
-            .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))
-            .write((flags & O_WRONLY != 0) | (flags & O_RDWR != 0))
+            .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))
+            .write((flags & O_ACCMODE == O_WRONLY) | (flags & O_ACCMODE == O_RDWR))
             .open(path)
             .map(|file| file.into())
             .map_err(|err| err.raw_os_error().unwrap())

--- a/src/context.rs
+++ b/src/context.rs
@@ -351,7 +351,7 @@ impl Libinput {
     /// # use std::fs::{File, OpenOptions};
     /// # use std::os::unix::{fs::OpenOptionsExt, io::OwnedFd};
     /// # use std::path::Path;
-    /// # use libc::{O_RDONLY, O_RDWR, O_WRONLY};
+    /// # use libc::{O_ACCMODE, O_RDONLY, O_RDWR, O_WRONLY};
     /// #
     /// use input::{Libinput, LibinputInterface};
     /// use rustix::event::{poll, PollFlags, PollFd};
@@ -362,8 +362,8 @@ impl Libinput {
     /// #     fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
     /// #         OpenOptions::new()
     /// #             .custom_flags(flags)
-    /// #             .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))
-    /// #             .write((flags & O_WRONLY != 0) | (flags & O_RDWR != 0))
+    /// #             .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))
+    /// #             .write((flags & O_ACCMODE == O_WRONLY) | (flags & O_ACCMODE == O_RDWR))
     /// #             .open(path)
     /// #             .map(|file| file.into())
     /// #             .map_err(|err| err.raw_os_error().unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! use std::path::Path;
 //!
 //! extern crate libc;
-//! use libc::{O_RDONLY, O_RDWR, O_WRONLY};
+//! use libc::{O_ACCMODE, O_RDONLY, O_RDWR, O_WRONLY};
 //!
 //! struct Interface;
 //!
@@ -47,8 +47,8 @@
 //!     fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
 //!         OpenOptions::new()
 //!             .custom_flags(flags)
-//!             .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))
-//!             .write((flags & O_WRONLY != 0) | (flags & O_RDWR != 0))
+//!             .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))
+//!             .write((flags & O_ACCMODE == O_WRONLY) | (flags & O_ACCMODE == O_RDWR))
 //!             .open(path)
 //!             .map(|file| file.into())
 //!             .map_err(|err| err.raw_os_error().unwrap())


### PR DESCRIPTION
The original code masks flags with O_RDONLY, which is 0:

> .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))

This generates Clippy errors because it's equivalent to 0 & 0 != 0.

The correct code uses O_ACCMODE to mask off the lower bits:

> .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))

The code could be further simplified with `let access_flags = flags & O_ACCMODE` at the top, but this version maintains the original intent and consistency with similar libinput examples across the internet.

This commit updates all 3 occurrences of the code fragment.

Fixes Smithay/input.rs#66