### PR TITLE
Move the usage example to `./examples`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features
+          args: --all --all-features --all-targets
 
   check-minimal:
     runs-on: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all --all-features -Z minimal-versions
+          args: --all --all-features --all-targets -Z minimal-versions
 
   test:
     needs:

--- a/README.md
+++ b/README.md
@@ -31,40 +31,4 @@ Fedora
 dnf install libinput-devel
 ```
 
-Configure and run event loop:
-
-```rust
-use input::{Libinput, LibinputInterface};
-use libc::{O_ACCMODE, O_RDONLY, O_RDWR, O_WRONLY};
-use std::fs::{File, OpenOptions};
-use std::os::unix::{fs::OpenOptionsExt, io::OwnedFd};
-use std::path::Path;
-
-struct Interface;
-
-impl LibinputInterface for Interface {
-    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
-        OpenOptions::new()
-            .custom_flags(flags)
-            .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))
-            .write((flags & O_ACCMODE == O_WRONLY) | (flags & O_ACCMODE == O_RDWR))
-            .open(path)
-            .map(|file| file.into())
-            .map_err(|err| err.raw_os_error().unwrap())
-    }
-    fn close_restricted(&mut self, fd: OwnedFd) {
-        drop(File::from(fd));
-    }
-}
-
-fn main() {
-    let mut input = Libinput::new_with_udev(Interface);
-    input.udev_assign_seat("seat0").unwrap();
-    loop {
-        input.dispatch().unwrap();
-        for event in &mut input {
-            println!("Got event: {:?}", event);
-        }
-    }
-}
-```
+For usage examples, see [Examples](https://github.com/Smithay/input.rs/tree/master/examples).

--- a/examples/event_loop.rs
+++ b/examples/event_loop.rs
@@ -1,0 +1,35 @@
+//! Configure and run event loop
+
+use input::{Libinput, LibinputInterface};
+use libc::{O_ACCMODE, O_RDONLY, O_RDWR, O_WRONLY};
+use std::fs::{File, OpenOptions};
+use std::os::unix::{fs::OpenOptionsExt, io::OwnedFd};
+use std::path::Path;
+
+struct Interface;
+
+impl LibinputInterface for Interface {
+    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
+        OpenOptions::new()
+            .custom_flags(flags)
+            .read((flags & O_ACCMODE == O_RDONLY) | (flags & O_ACCMODE == O_RDWR))
+            .write((flags & O_ACCMODE == O_WRONLY) | (flags & O_ACCMODE == O_RDWR))
+            .open(path)
+            .map(|file| file.into())
+            .map_err(|err| err.raw_os_error().unwrap())
+    }
+    fn close_restricted(&mut self, fd: OwnedFd) {
+        drop(File::from(fd));
+    }
+}
+
+fn main() {
+    let mut input = Libinput::new_with_udev(Interface);
+    input.udev_assign_seat("seat0").unwrap();
+    loop {
+        input.dispatch().unwrap();
+        for event in &mut input {
+            println!("Got event: {:?}", event);
+        }
+    }
+}


### PR DESCRIPTION
This will allow:
- the maintainers: to check that it still compiles, run Clippy on it in CI, etc.
- the users: to directly run the example using `cargo run --example event_loop`